### PR TITLE
should use "Written in Japanese"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ List pull requests for range: `TagA...TagB`
 
 ## Article
 
-https://qiita.com/Nkzn/items/60b30f1c9d0e33dfc424 (Japanese Only)
+https://qiita.com/Nkzn/items/60b30f1c9d0e33dfc424 (Written in Japanese)


### PR DESCRIPTION
Hi, I'm a "Japanese Only" police officer. 👮🏼 

You shouldn't use "Japanese Only", because some people feel that it means "Japanese people only".
I guess It's not what you intended.

If you want to notify that "The article is written in Japanese", you just use "Written in Japanese".

ref. https://next49.hatenadiary.jp/entry/20140428/p1 (Written in Japanese)
ref. https://www.wdic.org/w/WDIC/Japanese+only (Written in Japanese)